### PR TITLE
Reinstate custom serializer option

### DIFF
--- a/src/Shared/DefaultSerializer.cs
+++ b/src/Shared/DefaultSerializer.cs
@@ -1,0 +1,39 @@
+﻿//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+//
+
+using System.IO;
+using System.Web.SessionState;
+
+namespace Microsoft.Web.Redis
+{
+    internal class DefaultSerializer : ISerializer
+    {
+        public byte[] SerializeSessionStateItemCollection(SessionStateItemCollection sessionStateItemCollection)
+        {
+            if (sessionStateItemCollection is null)
+            {
+                return null;
+            }
+
+            MemoryStream ms = new MemoryStream();
+            BinaryWriter writer = new BinaryWriter(ms);
+            sessionStateItemCollection.Serialize(writer);
+            writer.Close();
+            return ms.ToArray();
+        }
+
+        public SessionStateItemCollection DeserializeSessionStateItemCollection(byte[] serializedSessionStateItemCollection)
+        {
+            if (serializedSessionStateItemCollection is null)
+            {
+                return null;
+            }
+
+            MemoryStream ms = new MemoryStream(serializedSessionStateItemCollection);
+            BinaryReader reader = new BinaryReader(ms);
+            return SessionStateItemCollection.Deserialize(reader);
+        }
+    }
+}

--- a/src/Shared/ISerializer.cs
+++ b/src/Shared/ISerializer.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+//
+
+using System.Web.SessionState;
+
+namespace Microsoft.Web.Redis
+{
+    public interface ISerializer
+    {
+        byte[] SerializeSessionStateItemCollection(SessionStateItemCollection sessionStateItemCollection);
+        SessionStateItemCollection DeserializeSessionStateItemCollection(byte[] serializedSessionStateItemCollection);
+    }
+}

--- a/src/Shared/ProviderConfiguration.cs
+++ b/src/Shared/ProviderConfiguration.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Web.Redis
         public int ConnectionTimeoutInMilliSec { get; set; }
         public int OperationTimeoutInMilliSec { get; set; }
         public string ConnectionString { get; set; }
+        public string RedisSerializerType { get; set; }
 
         /* Empty constructor required for testing */
 
@@ -84,6 +85,7 @@ namespace Microsoft.Web.Redis
             Port = GetIntSettings(config, "port", 0);
             AccessKey = GetStringSettings(config, "accessKey", null);
             UseSsl = GetBoolSettings(config, "ssl", true);
+            RedisSerializerType = GetStringSettings(config, "redisSerializerType", null);
             // All below parameters are only fetched from web.config
             DatabaseId = GetIntSettings(config, "databaseId", 0);
             ApplicationName = GetStringSettings(config, "applicationName", null);

--- a/src/Shared/StackExchangeClientConnection.cs
+++ b/src/Shared/StackExchangeClientConnection.cs
@@ -15,11 +15,13 @@ namespace Microsoft.Web.Redis
     {
         private ProviderConfiguration _configuration;
         private RedisSharedConnection _sharedConnection;
+        private ISerializer _serializer;
 
-        public StackExchangeClientConnection(ProviderConfiguration configuration, RedisSharedConnection sharedConnection)
+        public StackExchangeClientConnection(ProviderConfiguration configuration, RedisSharedConnection sharedConnection, ISerializer serializer)
         {
             _configuration = configuration;
             _sharedConnection = sharedConnection;
+            _serializer = serializer;
         }
 
         // This is used just by tests
@@ -186,9 +188,7 @@ namespace Microsoft.Web.Redis
 
         private SessionStateItemCollection DeserializeSessionStateItemCollection(RedisResult serializedSessionStateItemCollection)
         {
-            MemoryStream ms = new MemoryStream((byte[])serializedSessionStateItemCollection);
-            BinaryReader reader = new BinaryReader(ms);
-            return SessionStateItemCollection.Deserialize(reader);
+            return _serializer.DeserializeSessionStateItemCollection((byte[])serializedSessionStateItemCollection);
         }
 
         public void Set(string key, byte[] data, DateTime utcExpiry)

--- a/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
+++ b/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />

--- a/test/OutputCacheProviderUnitTests/RedisOutputCacheProvider.UnitTests.csproj
+++ b/test/OutputCacheProviderUnitTests/RedisOutputCacheProvider.UnitTests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />

--- a/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />

--- a/test/RedisSessionStateProviderFunctionalTests/StackExchangeClientConnectionFunctionalTests.cs
+++ b/test/RedisSessionStateProviderFunctionalTests/StackExchangeClientConnectionFunctionalTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Web.Redis.FunctionalTests
         private StackExchangeClientConnection GetStackExchangeClientConnection(ProviderConfiguration configuration)
         {
             var sharedConnection = new RedisSharedConnection(configuration);
-            return new StackExchangeClientConnection(configuration, sharedConnection);
+            return new StackExchangeClientConnection(configuration, sharedConnection, new DefaultSerializer());
         }
     }
 }

--- a/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
+++ b/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />

--- a/test/Shared/RedisServer.cs
+++ b/test/Shared/RedisServer.cs
@@ -7,6 +7,9 @@ using System;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 namespace Microsoft.Web.Redis.FunctionalTests
 {

--- a/test/Shared/TestSerializer.cs
+++ b/test/Shared/TestSerializer.cs
@@ -1,0 +1,78 @@
+﻿//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+//
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web.SessionState;
+
+namespace Microsoft.Web.Redis.Tests
+{
+    /// <summary>
+    /// This is not performant! It's just a naive implementation for testing.
+    /// </summary>
+    internal class TestSerializer : ISerializer
+    {
+        public byte[] SerializeSessionStateItemCollection(SessionStateItemCollection sessionStateItemCollection)
+        {
+            if (sessionStateItemCollection is null)
+            {
+                return null;
+            }
+
+            var d = new DictionaryWrapper {
+                Items = sessionStateItemCollection.Keys.OfType<string>().ToDictionary(key => key, key => sessionStateItemCollection[key]),
+                NullItem = sessionStateItemCollection[null]
+            };
+
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(d));
+        }
+
+        public SessionStateItemCollection DeserializeSessionStateItemCollection(byte[] serializedSessionStateItemCollection)
+        {
+            if (serializedSessionStateItemCollection is null)
+            {
+                return null;
+            }
+
+            var d = JsonConvert.DeserializeObject<DictionaryWrapper>(Encoding.UTF8.GetString(serializedSessionStateItemCollection, 0, serializedSessionStateItemCollection.Length));
+
+            var sessionItems = new SessionStateItemCollection();
+
+            if (d?.NullItem != null)
+            {
+                sessionItems[null] = d.NullItem;
+            }
+
+            if (d?.Items != null)
+            {
+                foreach (var item in d.Items)
+                {
+                    sessionItems[item.Key] = item.Value;
+                }
+            }
+
+            return sessionItems;
+        }
+
+        // Found in this answer: https://stackoverflow.com/a/30673807
+        internal class DictionaryWrapper
+        {
+            public DictionaryWrapper()
+            {
+                Items = new Dictionary<string, object>();
+            }
+
+            // Holds the value of the item with a null key, if any.
+            [JsonProperty(ItemTypeNameHandling = TypeNameHandling.Auto, DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public object NullItem { get; set; }
+
+            [JsonProperty(ItemTypeNameHandling = TypeNameHandling.Auto)]
+            public Dictionary<string, object> Items { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
This PR reinstates the option to use a custom serializer to serialize session item collections.